### PR TITLE
Reduce garbage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'net.zethmayr.fungu'
-version '1.0.1-SNAPSHOT'
+version '1.0.2-SNAPSHOT'
 description 'Functional Glue'
 
 static boolean isLocal(final String version) {

--- a/src/main/java/net/zethmayr/fungu/ConsumerFactory.java
+++ b/src/main/java/net/zethmayr/fungu/ConsumerFactory.java
@@ -32,7 +32,7 @@ public final class ConsumerFactory {
      * @param <T> the type done nothing with.
      * @return a consumer.
      */
-    public static <T> Consumer<T> nothing() {
+    public static <T> Consumer<T> nowhere() {
         return x -> {
         };
     }

--- a/src/main/java/net/zethmayr/fungu/DecisionHelper.java
+++ b/src/main/java/net/zethmayr/fungu/DecisionHelper.java
@@ -1,16 +1,23 @@
 package net.zethmayr.fungu;
 
-import net.zethmayr.fungu.core.ExceptionFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static net.zethmayr.fungu.core.ExceptionFactory.becauseStaticsOnly;
+import static net.zethmayr.fungu.core.SupplierFactory.nothing;
+
 /**
- * Provides common evaluations to boolean.
+ * Provides some common logical evaluations.
  */
 public final class DecisionHelper {
     private DecisionHelper() {
-        throw ExceptionFactory.becauseStaticsOnly();
+        throw becauseStaticsOnly();
     }
 
     /**
@@ -22,5 +29,118 @@ public final class DecisionHelper {
     public static boolean anyNull(final Object... values) {
         return Stream.of(values)
                 .anyMatch(Objects::isNull);
+    }
+
+    /**
+     * Returns a function which applies the given test,
+     * returning the first supplier result when the test passes
+     * and the second supplier result when the test fails.
+     *
+     * @param test      the test.
+     * @param supplier  the supplier when the test passes.
+     * @param whenFalse the supplier when the test fails.
+     * @param <T>       the tested type.
+     * @param <R>       the result type.
+     * @return a function returning a supplied result.
+     */
+    @NotNull
+    public static <T, R> Function<T, @Nullable R> maybeGet(
+            @NotNull final Predicate<T> test, @NotNull final Supplier<R> supplier, @NotNull final Supplier<R> whenFalse
+    ) {
+        return t -> test.test(t) ? supplier.get() : whenFalse.get();
+
+    }
+
+    /**
+     * Returns a function which applies the given test,
+     * returning the supplied result when the test passes,
+     * and null when the test fails.
+     *
+     * @param test     the test.
+     * @param supplier the supplier when the test passes.
+     * @param <T>      the tested type.
+     * @param <R>      the result type.
+     * @return a function returning a supplied result, or null.
+     */
+    @NotNull
+    public static <T, R> Function<T, @Nullable R> maybeGet(
+            @NotNull final Predicate<T> test, @NotNull final Supplier<R> supplier
+    ) {
+        return maybeGet(test, supplier, nothing());
+    }
+
+    /**
+     * Returns a function which applies the given test,
+     * applying the given function when the test passes,
+     * and using the given supplier when the test fails.
+     *
+     * @param test      the test.
+     * @param mapper    the mapper for values passing the test.
+     * @param whenFalse the supplier when the test fails.
+     * @param <T>       the tested type.
+     * @param <R>       the result type.
+     * @return a function.
+     */
+    @NotNull
+    public static <T, R> Function<T, R> maybeApply(
+            @NotNull final Predicate<T> test, @NotNull final Function<T, R> mapper, @NotNull final Supplier<R> whenFalse
+    ) {
+        return t -> test.test(t) ? mapper.apply(t) : whenFalse.get();
+    }
+
+    /**
+     * Returns a function which applies the given test,
+     * applying the given function when the test passes,
+     * and returning null when the test fails.
+     *
+     * @param test   the test.
+     * @param mapper the mapper for values passing the test.
+     * @param <T>    the tested type.
+     * @param <R>    the result type.
+     * @return a function.
+     */
+    @NotNull
+    public static <T, R> Function<T, @Nullable R> maybeApply(
+            @NotNull final Predicate<T> test, @NotNull final Function<T, R> mapper
+    ) {
+        return maybeApply(test, mapper, nothing());
+    }
+
+    /**
+     * Returns a function which applies the given test,
+     * returning the given result when the test passes,
+     * and using the given supplier when the test fails.
+     *
+     * @param test     the test.
+     * @param result   the result when the test passes.
+     * @param whenNull the supplier when the test fails.
+     * @param <T>      the tested type.
+     * @param <R>      the result type.
+     * @return a function.
+     */
+    @NotNull
+    public static <T, R> Function<T, @Nullable R> maybeResult(
+            @NotNull final Predicate<T> test, @Nullable final R result, @NotNull final Supplier<R> whenNull
+    ) {
+        return t -> test.test(t) ? result : whenNull.get();
+
+    }
+
+    /**
+     * Returns a function which applies the given test,
+     * returning the given result when the test passes,
+     * and null when the test fails.
+     *
+     * @param test   the tested type.
+     * @param result the result for passing tests.
+     * @param <T>    the tested type.
+     * @param <R>    the result type.
+     * @return a function.
+     */
+    @NotNull
+    public static <T, R> Function<T, @Nullable R> maybeResult(
+            @NotNull final Predicate<T> test, @Nullable final R result
+    ) {
+        return maybeResult(test, result, nothing());
     }
 }

--- a/src/main/java/net/zethmayr/fungu/arc/ProtectedCountedReference.java
+++ b/src/main/java/net/zethmayr/fungu/arc/ProtectedCountedReference.java
@@ -3,7 +3,7 @@ package net.zethmayr.fungu.arc;
 import java.io.Closeable;
 
 import static net.zethmayr.fungu.CloseableFactory.closeIntercepted;
-import static net.zethmayr.fungu.ConsumerFactory.nothing;
+import static net.zethmayr.fungu.ConsumerFactory.nowhere;
 
 /**
  * This counted reference
@@ -28,7 +28,7 @@ public abstract class ProtectedCountedReference<T extends Closeable> extends Sim
      */
     protected ProtectedCountedReference(final Class<T> resourceInterface, final Class<?>... additionalInterfaces) {
         super();
-        closeProtected = closeIntercepted(resourceInterface, super.getResource(), nothing(), additionalInterfaces);
+        closeProtected = closeIntercepted(resourceInterface, super.getResource(), nowhere(), additionalInterfaces);
     }
 
     /**

--- a/src/main/java/net/zethmayr/fungu/core/SupplierFactory.java
+++ b/src/main/java/net/zethmayr/fungu/core/SupplierFactory.java
@@ -14,6 +14,13 @@ public final class SupplierFactory {
     }
 
     /**
+     * Returns a supplier with a covariant null result.
+     */
+    public static <T> Supplier<T> nothing() {
+        return () -> null;
+    }
+
+    /**
      * Returns a supplier with a fixed value.
      *
      * @param value the value.

--- a/src/test/java/net/zethmayr/fungu/CoalescenceHelperTest.java
+++ b/src/test/java/net/zethmayr/fungu/CoalescenceHelperTest.java
@@ -9,10 +9,17 @@ import static java.util.function.Function.identity;
 import static net.zethmayr.fungu.CoalescenceHelper.*;
 import static net.zethmayr.fungu.core.SupplierFactory.from;
 import static net.zethmayr.fungu.test.TestConstants.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static net.zethmayr.fungu.test.TestHelper.invokeDefaultConstructor;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CoalescenceHelperTest {
+
+    @Test
+    void coalescenceHelper_whenInstantiated_throwsInstead() {
+        assertThrows(UnsupportedOperationException.class, () ->
+
+                invokeDefaultConstructor(CoalescenceHelper.class));
+    }
 
     @Test
     void coalesce_givenNull_returnsNull() {

--- a/src/test/java/net/zethmayr/fungu/ConsumerFactoryTest.java
+++ b/src/test/java/net/zethmayr/fungu/ConsumerFactoryTest.java
@@ -23,7 +23,7 @@ class ConsumerFactoryTest {
     @Test
     void nothing_givenValue_doesNothing() {
 
-        final Consumer<String> underTest = nothing();
+        final Consumer<String> underTest = nowhere();
         underTest.accept(EXPECTED);
 
         assertNotNull(underTest);

--- a/src/test/java/net/zethmayr/fungu/DecisionHelperTest.java
+++ b/src/test/java/net/zethmayr/fungu/DecisionHelperTest.java
@@ -1,0 +1,104 @@
+package net.zethmayr.fungu;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import static net.zethmayr.fungu.DecisionHelper.*;
+import static net.zethmayr.fungu.core.SupplierFactory.from;
+import static net.zethmayr.fungu.test.TestConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DecisionHelperTest {
+
+    @Test
+    void anyNull_whenNone_returnsFalse() {
+
+        assertFalse(anyNull());
+    }
+
+    @Test
+    void anyNull_whenNull_returnsTrue() {
+
+        assertTrue(anyNull(NULL_STRING));
+    }
+
+    @Test
+    void anyNull_whenNonNull_returnsFalse() {
+
+        assertFalse(anyNull(EXPECTED));
+    }
+
+    @Test
+    void anyNull_whenNonNullAndNull_returnsTrue() {
+
+        assertTrue(anyNull(EXPECTED, NULL_STRING));
+    }
+
+    @Test
+    void anyNull_whenNullAndNonNull_returnsTrue() {
+
+        assertTrue(anyNull(NULL_STRING, EXPECTED));
+    }
+
+    @Test
+    void anyNull_whenTwoNonNull_returnsFalse() {
+
+        assertFalse(anyNull(EXPECTED, SHIBBOLETH));
+    }
+
+    @Test
+    void anyNull_whenTwoNull_returnsTrue() {
+
+        assertTrue(anyNull(NULL_OBJECT, NULL_STRING));
+    }
+
+    @Test
+    void maybeGet_givenTestAndSupplier_whenTestFails_returnsNull() {
+
+        final Function<Object, String> underTest = maybeGet(Objects::nonNull, from(UNEXPECTED));
+
+        assertNull(underTest.apply(NULL_OBJECT));
+    }
+
+    @Test
+    void maybeGet_givenTestAndSupplier_whenTestPasses_returnsSuppliedValue() {
+
+        final Function<Object, String> underTest = maybeGet(Objects::nonNull, from(EXPECTED));
+
+        assertEquals(EXPECTED, underTest.apply(UNEXPECTED));
+    }
+
+    @Test
+    void maybeApply_givenTestAndMapper_whenTestFails_returnsNull() {
+
+        final Function<String, Integer> underTest = maybeApply(EXPECTED::equals, String::length);
+
+        assertNull(underTest.apply(UNEXPECTED));
+    }
+
+    @Test
+    void maybeApply_givenTestAndMapper_whenTestPasses_returnsResult() {
+
+        final Function<String, Integer> underTest = maybeApply(EXPECTED::equals, String::length);
+
+        assertEquals(8, underTest.apply(EXPECTED));
+    }
+
+    @Test
+    void maybeResult_givenTestAndResult_whenTestFails_returnsNull() {
+
+        final Function<String, Object> underTest = maybeResult(UNEXPECTED::equals, NOT_EVEN_WRONG);
+
+        assertNull(underTest.apply(EXPECTED));
+    }
+
+    @Test
+    void maybeResult_givenTestAndResult_whenTestPasses_returnsResult() {
+
+        final Function<Object, String> underTest = maybeResult(SHIBBOLETH::equals, EXPECTED);
+
+        assertEquals(EXPECTED, underTest.apply(SHIBBOLETH));
+    }
+}

--- a/src/test/java/net/zethmayr/fungu/arc/Testable.java
+++ b/src/test/java/net/zethmayr/fungu/arc/Testable.java
@@ -6,3 +6,4 @@ public interface Testable extends Closeable {
     boolean isClosed();
 
     int getValue();
+}

--- a/src/test/java/net/zethmayr/fungu/arc/Testable.java
+++ b/src/test/java/net/zethmayr/fungu/arc/Testable.java
@@ -6,4 +6,3 @@ public interface Testable extends Closeable {
     boolean isClosed();
 
     int getValue();
-}

--- a/src/test/java/net/zethmayr/fungu/throwing/SinkFactoryTest.java
+++ b/src/test/java/net/zethmayr/fungu/throwing/SinkFactoryTest.java
@@ -18,7 +18,7 @@ class SinkFactoryTest {
     @Test
     void sink_givenNothing_returnsSink_whenAcceptThenRaise_throwsAccepted() {
         final Exception thrown = new Exception();
-        final Sink underTest = sink();
+        final Sink<Exception> underTest = sink();
 
         assertInstanceOf(Sink.class, underTest);
         underTest.accept(thrown);
@@ -31,7 +31,7 @@ class SinkFactoryTest {
     void sink_givenNothing_returnsSink_whenAcceptTwiceBeforeRaise_throwsFirstSuppressingSecond() {
         final Exception firstThrown = new Exception();
         final Exception secondThrown = new Exception();
-        final Sink underTest = sink();
+        final Sink<Exception> underTest = sink();
 
         assertInstanceOf(Sink.class, underTest);
         underTest.accept(firstThrown);
@@ -45,7 +45,7 @@ class SinkFactoryTest {
     @Test
     void hole_givenNothing_returnsSink_whenAcceptThenRaise_doesNothing() throws Exception {
         final Exception thrown = new Exception();
-        final Sink underTest = hole();
+        final Sink<Exception> underTest = hole();
 
         assertInstanceOf(Sink.class, underTest);
         underTest.accept(thrown);
@@ -55,7 +55,7 @@ class SinkFactoryTest {
     @Test
     void mine_givenNothing_returnsSink_whenAccept_throwsWrapped() {
         final Exception thrown = new Exception();
-        final Sink underTest = mine();
+        final Sink<Exception> underTest = mine();
 
         assertInstanceOf(Sink.class, underTest);
         final RuntimeException caught = assertThrows(RuntimeException.class, () ->
@@ -67,7 +67,7 @@ class SinkFactoryTest {
     @Test
     void threadSafeSink_givenNothing_returnsSink_whenAcceptThenRaise_throwsAccepted() {
         final Exception thrown = new Exception();
-        final Sink underTest = threadSafeSink();
+        final Sink<Exception> underTest = threadSafeSink();
 
         assertInstanceOf(Sink.class, underTest);
         underTest.accept(thrown);


### PR DESCRIPTION
Makes `coalesce` family verifiably garbage-free in implementation
Updates some tests (Sink typing)